### PR TITLE
feat: Migrate deployment documentation from GitHub Pages to Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To build the project for production, run:
 npm run build
 ```
 
-The build artifacts will be stored in the `docs/` directory, which is configured for deployment on GitHub Pages. The build process automatically includes essential files like `CNAME`, `robots.txt`, and `sitemap.xml`.
+The build artifacts will be stored in the `docs/` directory. This project is configured for continuous deployment on Netlify. The build process automatically includes essential files like `robots.txt`, and `sitemap.xml`.
 
 ## built-with-angular
 * **Angular:** ^19.2.0

--- a/angular.json
+++ b/angular.json
@@ -36,8 +36,7 @@
               "src/favicon.ico", 
               "src/assets",
               "src/robots.txt",
-              "src/sitemap.xml",
-              "src/CNAME",
+                            "src/sitemap.xml",
               "src/404.html"
             ],
             "styles": [

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-www.mririce.com

--- a/gemini.md
+++ b/gemini.md
@@ -27,10 +27,10 @@ The application is a **standalone Angular single-page application (SPA)**. It ut
 
 ### 1.3. Build & Deployment
 
-The build process is configured in `angular.json` and is optimized for GitHub Pages deployment.
+The build process is configured in `angular.json` and is optimized for Netlify deployment.
 
-*   **Output Path:** The build output is directed to the `docs/` directory, which is the standard for GitHub Pages.
-*   **Asset Management:** The build process correctly copies static assets, including SEO-critical files like `robots.txt`, `sitemap.xml`, and `CNAME`, to the output directory.
+*   **Output Path:** The build output is directed to the `docs/` directory, as specified in `netlify.toml`.
+*   **Asset Management:** The build process correctly copies static assets, including SEO-critical files like `robots.txt` and `sitemap.xml`, to the output directory.
 *   **Production Build:** The production configuration enables `outputHashing` for cache busting and sets budget limits to monitor application size.
 
 ## 2. Core Features & Implementation

--- a/src/CNAME
+++ b/src/CNAME
@@ -1,1 +1,0 @@
-www.mririce.com


### PR DESCRIPTION
- Update README.md and gemini.md to reflect Netlify deployment.

- Remove CNAME files previously used for GitHub Pages.

- Update angular.json to remove reference to CNAME file.