### PR TITLE
fix: Handle non-JSON response for contact form submission\n\nThis com…

### DIFF
--- a/src/app/services/contact.service.ts
+++ b/src/app/services/contact.service.ts
@@ -20,6 +20,6 @@ export class ContactService {
       body.set(key, data[key]);
     });
 
-    return this.http.post('/', body.toString(), { headers: headers });
+    return this.http.post('/', body.toString(), { headers: headers, responseType: 'text' });
   }
 }


### PR DESCRIPTION
…mit modifies the ContactService.send method to explicitly set responseType: text for the HttpClient POST request, ensuring the response is treated as plain text and preventing parsing errors.